### PR TITLE
Use TLSv1_2_client_method (maybe?)

### DIFF
--- a/src/dnet.c
+++ b/src/dnet.c
@@ -172,7 +172,7 @@ dnetUseTls(dsocket *sd)
 		return ERROR;
 	}
 	_genRandomSeed();
-	sd->ctx = SSL_CTX_new(TLSv1_client_method());
+	sd->ctx = SSL_CTX_new(TLSv1_2_client_method());
 	if (!sd->ctx) {
 		return ERROR;
 	}


### PR DESCRIPTION
Hello,

I got his error message after running the command-line:

```
email: FATAL: Smtp error: Timeout(10) while trying to read from SMTP server
```

I've followed instructions found in 
 - [https://github.com/deanproxy/eMail/issues/58](https://github.com/deanproxy/eMail/issues/58).
 - [https://github.com/deanproxy/eMail/issues/59](https://github.com/deanproxy/eMail/issues/59)

Besides, I found this method in OpenSSL manpages: [TLSv1_2_client_method](https://www.openssl.org/docs/man3.0/man3/TLSv1_2_client_method.html).

Please let me know if that or something else entirely could help somehow.